### PR TITLE
Use SSL while fetching chat id

### DIFF
--- a/app/models/stack_user.rb
+++ b/app/models/stack_user.rb
@@ -10,7 +10,7 @@ class StackUser < ApplicationRecord
       self.username = user_json['items'][0]['display_name']
 
       # Haaaaaaaaack.
-      self.chat_so_id = Net::HTTP.get_response(URI.parse("http://chat.stackoverflow.com/accounts/#{self.network_id}"))["location"].scan(/\/users\/(\d*)\//)[0][0]
+      self.chat_so_id = Net::HTTP.get_response(URI.parse("https://chat.stackoverflow.com/accounts/#{self.network_id}"))["location"].scan(/\/users\/(\d*)\//)[0][0]
 
       self.save
     else


### PR DESCRIPTION
For new users, fetching the chat id without SSL leads to an error:

    <html><head><title>Object moved</title></head><body>
    <h2>Object moved to <a href="https://chat.stackoverflow.com/accounts/5963824">here</a>.</h2>
    </body></html>
