### PR TITLE
Fix flag options order

### DIFF
--- a/app/assets/javascripts/posts.js
+++ b/app/assets/javascripts/posts.js
@@ -32,7 +32,7 @@ $(document).ready(function() {
                             }
                         }
                     });
-                    flagOption.prependTo(dialog);
+                    flagOption.appendTo(dialog);
                 }
             }
             $(".modal").first().modal('show');


### PR DESCRIPTION
Currently, the flag options are reversed; the option which appears at the bottom on SE appears at the top on Sentinel. This is somewhat irritating as most of us are used to the standard order of flag options.

Instead of prepending to the flag dialog, this appends thus making the order as usual.